### PR TITLE
Fixes #164  - Empty comments

### DIFF
--- a/src/archiefvernietigingscomponent/destruction/views.py
+++ b/src/archiefvernietigingscomponent/destruction/views.py
@@ -253,7 +253,7 @@ class DestructionListDetailView(AuthorOrAssigneeRequiredMixin, UpdateWithInlines
         )
 
         # Check if there are comments from the author
-        if "text" in self.request.POST:
+        if "text" in self.request.POST and self.request.POST["text"] != "":
             comment = DestructionListReviewComment(
                 review=destruction_list.last_review()
             )

--- a/src/archiefvernietigingscomponent/destruction/views.py
+++ b/src/archiefvernietigingscomponent/destruction/views.py
@@ -253,7 +253,7 @@ class DestructionListDetailView(AuthorOrAssigneeRequiredMixin, UpdateWithInlines
         )
 
         # Check if there are comments from the author
-        if "text" in self.request.POST and self.request.POST["text"] != "":
+        if self.request.POST.get("text"):
             comment = DestructionListReviewComment(
                 review=destruction_list.last_review()
             )


### PR DESCRIPTION
Fixes #164 

Now, if a record manager leaves empty comments, they are not created.