### PR TITLE
Fixes #165 - Relate a report to a destruction list 

### DIFF
--- a/src/archiefvernietigingscomponent/report/utils.py
+++ b/src/archiefvernietigingscomponent/report/utils.py
@@ -172,6 +172,7 @@ def create_destruction_report(destruction_list: DestructionList) -> DestructionR
         title=report_subject,
         process_owner=process_owner_review.author if process_owner_review else None,
         content=ContentFile(content=report_content, name=report_filename),
+        destruction_list=destruction_list,
     )
 
     return destruction_report


### PR DESCRIPTION
Fixes #165 

Now when the destruction report is created it is *actually* related to the destruction list.