### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,7 +30,7 @@ cffi==1.14.0
     #   weasyprint
 chardet==3.0.4
     # via requests
-cryptography==2.9.2
+cryptography==3.3.2
     # via django-auth-adfs
 cssselect2==0.4.1
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -45,7 +45,7 @@ chardet==3.0.4
     #   requests
 coverage==4.5.4
     # via -r requirements/test-tools.in
-cryptography==2.9.2
+cryptography==3.3.2
     # via
     #   -r requirements/base.txt
     #   django-auth-adfs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,7 +61,7 @@ click==7.1.2
     #   pip-tools
 coverage==4.5.4
     # via -r requirements/ci.txt
-cryptography==2.9.2
+cryptography==3.3.2
     # via
     #   -r requirements/ci.txt
     #   django-auth-adfs


### PR DESCRIPTION
Fixes https://github.com/maykinmedia/archiefvernietigingscomponent/pull/194

The bot only seems to update the `ci.txt`.