### PR TITLE
Issue #218 - Duplicate lists

### DIFF
--- a/src/archiefvernietigingscomponent/destruction/filters.py
+++ b/src/archiefvernietigingscomponent/destruction/filters.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.models import Q
 
 from django_filters import ChoiceFilter, FilterSet
 
@@ -28,9 +29,10 @@ class ReviewerListFilter(FilterSet):
         super().__init__(data, *args, **kwargs)
 
     def filter_reviewed(self, queryset, name, value):
+        user = self.request.user
         if value == ReviewerDisplay.to_review:
-            return queryset.filter(assignee=self.request.user)
+            return queryset.filter(assignee=user)
         elif value == ReviewerDisplay.reviewed:
-            return queryset.reviewed_by(self.request.user)
+            return queryset.filter(~Q(assignee=user))
         else:
             return queryset

--- a/src/archiefvernietigingscomponent/destruction/models.py
+++ b/src/archiefvernietigingscomponent/destruction/models.py
@@ -23,7 +23,6 @@ from .constants import (
     ReviewStatus,
     Suggestion,
 )
-from .query import DestructionListQuerySet
 
 
 class DestructionList(models.Model):
@@ -63,8 +62,6 @@ class DestructionList(models.Model):
         ),
         default=True,
     )
-
-    objects = DestructionListQuerySet.as_manager()
 
     class Meta:
         verbose_name = _("destruction list")

--- a/src/archiefvernietigingscomponent/destruction/query.py
+++ b/src/archiefvernietigingscomponent/destruction/query.py
@@ -1,8 +1,0 @@
-from django.db import models
-
-from archiefvernietigingscomponent.accounts.models import User
-
-
-class DestructionListQuerySet(models.QuerySet):
-    def reviewed_by(self, user: User):
-        return self.filter(reviews__author=user)

--- a/src/archiefvernietigingscomponent/destruction/tests/test_landing_page.py
+++ b/src/archiefvernietigingscomponent/destruction/tests/test_landing_page.py
@@ -85,6 +85,10 @@ class ReviewerTests(WebTest):
         cls.list_to_review = DestructionListFactory.create(
             assignee=cls.user, name="list to review"
         )
+        DestructionListReviewFactory.create(
+            destruction_list=cls.list_to_review, author=cls.user
+        )
+
         cls.list_reviewed = DestructionListFactory.create(name="list reviewed")
         DestructionListReviewFactory.create(
             destruction_list=cls.list_reviewed, author=cls.user


### PR DESCRIPTION
Fixes #218 

The problem was that the filter `.filter(reviews__author=user)` returns multiple times the same destruction list if it has been reviewed multiple times by the same reviewer (like in the case where changes have been requested).

So, to fix it, the queryset given from the view to the filter was deduplicated.

In addition, the filter was changed so that the lists that are assigned to the current reviewer are not shown in the "beoordeeld" subset (even if the reviewer has reviewed them before).